### PR TITLE
Improve Character Mapping and use pseudoRandomBytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ function tostr(bytes) {
 function uid(length, cb) {
 
   if (typeof cb === 'undefined') {
-    return tostr(crypto.randomBytes(length));
+    return tostr(crypto.pseudoRandomBytes(length));
   } else {
-    crypto.randomBytes(length, function(err, bytes) {
+    crypto.pseudoRandomBytes(length, function(err, bytes) {
        if (err) return cb(err);
        cb(null, tostr(bytes));
     })


### PR DESCRIPTION
- Directly map to 62 url-safe characters instead of going through base64 to get there.
- Use `crypto.pseudoRandomBytes` which is 'good enough' and 'less' blocky than `crypto.randomBytes` (this is due to how OpenSSL works underneath)
