### PR TITLE
Fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# uid2
+
+strong uid.  Pass in a `length` and it returns a `string`.
+
+[![NPM version](https://badge.fury.io/js/uid2.png)](http://badge.fury.io/js/uid2)
+
+## Installation
+
+    npm install uid2
+
+## Usage
+
+```javascript
+var uid = require('uid2');
+
+//synchronous usage
+var id = uid(length);
+
+//asynchronous usage
+uid(length, function (err, id) {
+  if (err) throw err;
+});
+```
+
+## License
+
+  MIT

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "tags": ["uid"],
   "version": "0.0.3",
   "dependencies": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Coreh/uid2.git"
   }
 }


### PR DESCRIPTION
Adds a basic readme and a `repository` link in the package.json

Both of these are necessary to prevent warnings in `npm`.
