### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "strong uid",
   "tags": ["uid"],
   "version": "0.0.3",
+  "license": "MIT",
   "dependencies": {
   }
 }


### PR DESCRIPTION
This makes it easier for tools like https://www.npmjs.org/package/licensing to identify the licenses of all of your dependencies and thus to ensure that your project only includes dependencies with a compatible license to your own.

Fixes #19 