### PR TITLE
pseudoRandomBytes deprecated in node >= 0.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var crypto = require('crypto');
  */
 var UIDCHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
+
 /**
  * Make a Buffer into a string ready for use in URLs
  *
@@ -37,11 +38,10 @@ function tostr(bytes) {
  */
 
 function uid(length, cb) {
-
   if (typeof cb === 'undefined') {
-    return tostr(crypto.pseudoRandomBytes(length));
+    return tostr(crypto.randomBytes(length));
   } else {
-    crypto.pseudoRandomBytes(length, function(err, bytes) {
+    crypto.randomBytes(length, function(err, bytes) {
        if (err) return cb(err);
        cb(null, tostr(bytes));
     })

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "description": "strong uid",
   "tags": ["uid"],
   "version": "0.0.3",
-  "dependencies": {
+  "repository": {
+    "type": "https",
+    "url": "https://github.com/coreh/uid2.git"
   }
 }


### PR DESCRIPTION
recent changes to node have deprecated `pseudoRandomBytes` See the comment from @bnoordhuis :

https://github.com/nodejs/node-v0.x-archive/issues/25821